### PR TITLE
Fix formatting mistakes in co-author names. 

### DIFF
--- a/_posts/2024-10-12-syrota24a.md
+++ b/_posts/2024-10-12-syrota24a.md
@@ -24,13 +24,13 @@ lastpage: 285
 page: 277-285
 order: 277
 cycles: false
-bibtex_author: Syrota, Stas and Moreno-Mu{\~ n}oz, Pablo and Hauberg, S\oren
+bibtex_author: Syrota, Stas and Moreno-Muñoz, Pablo and Hauberg, Søren
 author:
 - given: Stas
   family: Syrota
 - given: Pablo
-  family: Moreno-Mu\~ noz
-- given: S\oren
+  family: Moreno-Muñoz
+- given: Søren
   family: Hauberg
 date: 2024-10-12
 address:


### PR DESCRIPTION
Fix formatting mistakes in co-author names. 

Documenting changes: Søren's name: https://www2.compute.dtu.dk/~sohau/
Pablo's name: https://scholar.google.es/citations?user=8vL8iawAAAAJ&hl=en